### PR TITLE
feat: add PortForward HTTP methods (Post, Put, Delete, Do, URL)

### DIFF
--- a/context.go
+++ b/context.go
@@ -1665,8 +1665,58 @@ func (pf *PortForward) Get(path string) (*http.Response, error) {
 	if pf.err != nil {
 		return nil, pf.err
 	}
-	url := fmt.Sprintf("http://localhost:%d%s", pf.localPort, path)
-	return pf.httpClient.Get(url)
+	return pf.httpClient.Get(pf.URL(path))
+}
+
+// URL returns the full URL for a given path through the port forward.
+func (pf *PortForward) URL(path string) string {
+	return fmt.Sprintf("http://localhost:%d%s", pf.localPort, path)
+}
+
+// Post makes an HTTP POST request through the port forward.
+// Caller is responsible for closing the response body.
+func (pf *PortForward) Post(path, contentType string, body io.Reader) (*http.Response, error) {
+	if pf.err != nil {
+		return nil, pf.err
+	}
+	return pf.httpClient.Post(pf.URL(path), contentType, body)
+}
+
+// Put makes an HTTP PUT request through the port forward.
+// Caller is responsible for closing the response body.
+func (pf *PortForward) Put(path, contentType string, body io.Reader) (*http.Response, error) {
+	if pf.err != nil {
+		return nil, pf.err
+	}
+	req, err := http.NewRequest(http.MethodPut, pf.URL(path), body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", contentType)
+	return pf.httpClient.Do(req)
+}
+
+// Delete makes an HTTP DELETE request through the port forward.
+// Caller is responsible for closing the response body.
+func (pf *PortForward) Delete(path string) (*http.Response, error) {
+	if pf.err != nil {
+		return nil, pf.err
+	}
+	req, err := http.NewRequest(http.MethodDelete, pf.URL(path), nil)
+	if err != nil {
+		return nil, err
+	}
+	return pf.httpClient.Do(req)
+}
+
+// Do executes a custom HTTP request through the port forward.
+// Use this for PATCH, OPTIONS, or requests with custom headers.
+// Caller is responsible for closing the response body.
+func (pf *PortForward) Do(req *http.Request) (*http.Response, error) {
+	if pf.err != nil {
+		return nil, pf.err
+	}
+	return pf.httpClient.Do(req)
 }
 
 // Forward creates a port forward to a pod or service.

--- a/context_test.go
+++ b/context_test.go
@@ -1,7 +1,9 @@
 package ilmari
 
 import (
+	"bytes"
 	"context"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2370,6 +2372,215 @@ func TestCanIChecksPermissions(t *testing.T) {
 
 		if !canList {
 			t.Error("expected to be able to list deployments")
+		}
+	})
+}
+
+// TestPortForwardPost verifies Post sends HTTP POST requests.
+func TestPortForwardPost(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	Run(t, func(ctx *Context) {
+		// Deploy nginx - POST to static files returns 405, proving POST was sent
+		stack := NewStack().
+			Service("web").
+			Image("nginx:1.25-alpine").
+			Port(80).
+			Build()
+
+		if err := ctx.Up(stack); err != nil {
+			t.Fatalf("Up failed: %v", err)
+		}
+
+		pf := ctx.Forward("svc/web", 80)
+		defer pf.Close()
+
+		// Test Post - nginx returns 405 for POST to static files
+		resp, err := pf.Post("/", "application/json", strings.NewReader(`{"key":"value"}`))
+		if err != nil {
+			t.Fatalf("Post failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		// nginx returns 405 for POST to static resources - this proves POST was sent
+		if resp.StatusCode != 405 {
+			t.Errorf("expected 405 (POST not allowed), got %d", resp.StatusCode)
+		}
+	})
+}
+
+// TestPortForwardPut verifies Put sends HTTP PUT requests.
+func TestPortForwardPut(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	Run(t, func(ctx *Context) {
+		// Deploy nginx - PUT to static files returns 405, proving PUT was sent
+		stack := NewStack().
+			Service("web").
+			Image("nginx:1.25-alpine").
+			Port(80).
+			Build()
+
+		if err := ctx.Up(stack); err != nil {
+			t.Fatalf("Up failed: %v", err)
+		}
+
+		pf := ctx.Forward("svc/web", 80)
+		defer pf.Close()
+
+		// Test Put - nginx returns 405 for PUT
+		resp, err := pf.Put("/", "application/json", strings.NewReader(`{"updated":"data"}`))
+		if err != nil {
+			t.Fatalf("Put failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		// nginx returns 405 for PUT - proves the method was sent correctly
+		if resp.StatusCode != 405 {
+			t.Errorf("expected 405 (PUT not allowed), got %d", resp.StatusCode)
+		}
+	})
+}
+
+// TestPortForwardDelete verifies Delete sends HTTP DELETE requests.
+func TestPortForwardDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	Run(t, func(ctx *Context) {
+		// Deploy nginx - DELETE to static files returns 405
+		stack := NewStack().
+			Service("web").
+			Image("nginx:1.25-alpine").
+			Port(80).
+			Build()
+
+		if err := ctx.Up(stack); err != nil {
+			t.Fatalf("Up failed: %v", err)
+		}
+
+		pf := ctx.Forward("svc/web", 80)
+		defer pf.Close()
+
+		// Test Delete - nginx returns 405 for DELETE
+		resp, err := pf.Delete("/")
+		if err != nil {
+			t.Fatalf("Delete failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		// nginx returns 405 for DELETE - proves the method was sent correctly
+		if resp.StatusCode != 405 {
+			t.Errorf("expected 405 (DELETE not allowed), got %d", resp.StatusCode)
+		}
+	})
+}
+
+// TestPortForwardDo verifies Do sends custom HTTP requests.
+func TestPortForwardDo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	Run(t, func(ctx *Context) {
+		stack := NewStack().
+			Service("web").
+			Image("nginx:1.25-alpine").
+			Port(80).
+			Build()
+
+		if err := ctx.Up(stack); err != nil {
+			t.Fatalf("Up failed: %v", err)
+		}
+
+		pf := ctx.Forward("svc/web", 80)
+		defer pf.Close()
+
+		// Test Do with custom PATCH request
+		req, err := http.NewRequest("PATCH", pf.URL("/"), bytes.NewReader([]byte(`{"partial":"update"}`)))
+		if err != nil {
+			t.Fatalf("NewRequest failed: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Custom-Header", "test-value")
+
+		resp, err := pf.Do(req)
+		if err != nil {
+			t.Fatalf("Do failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		// nginx returns 405 for PATCH - proves the method was sent correctly
+		if resp.StatusCode != 405 {
+			t.Errorf("expected 405 (PATCH not allowed), got %d", resp.StatusCode)
+		}
+	})
+}
+
+// TestPortForwardURL verifies URL returns proper endpoint URLs.
+func TestPortForwardURL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	Run(t, func(ctx *Context) {
+		stack := NewStack().
+			Service("web").
+			Image("nginx:1.25-alpine").
+			Port(80).
+			Build()
+
+		if err := ctx.Up(stack); err != nil {
+			t.Fatalf("Up failed: %v", err)
+		}
+
+		pf := ctx.Forward("svc/web", 80)
+		defer pf.Close()
+
+		url := pf.URL("/health")
+		if !strings.HasPrefix(url, "http://localhost:") {
+			t.Errorf("expected URL to start with http://localhost:, got %s", url)
+		}
+		if !strings.HasSuffix(url, "/health") {
+			t.Errorf("expected URL to end with /health, got %s", url)
+		}
+	})
+}
+
+// TestPortForwardGetVerify verifies Get still works after refactoring.
+func TestPortForwardGetVerify(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	Run(t, func(ctx *Context) {
+		stack := NewStack().
+			Service("web").
+			Image("nginx:1.25-alpine").
+			Port(80).
+			Build()
+
+		if err := ctx.Up(stack); err != nil {
+			t.Fatalf("Up failed: %v", err)
+		}
+
+		pf := ctx.Forward("svc/web", 80)
+		defer pf.Close()
+
+		// GET should return 200 for nginx index
+		resp, err := pf.Get("/")
+		if err != nil {
+			t.Fatalf("Get failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Adds `Post(path, contentType, body)` for HTTP POST requests
- Adds `Put(path, contentType, body)` for HTTP PUT requests
- Adds `Delete(path)` for HTTP DELETE requests
- Adds `Do(req)` for custom requests (PATCH, OPTIONS, custom headers)
- Adds `URL(path)` helper to get full endpoint URL for manual request building
- Refactored `Get()` to use `URL()` internally for consistency

This enables full API testing through port-forwarded services, not just GET requests.

## Test plan
- [x] TestPortForwardPost - verifies POST requests (nginx returns 405)
- [x] TestPortForwardPut - verifies PUT requests (nginx returns 405)
- [x] TestPortForwardDelete - verifies DELETE requests (nginx returns 405)
- [x] TestPortForwardDo - verifies custom PATCH requests (nginx returns 405)
- [x] TestPortForwardURL - verifies URL formatting
- [x] TestPortForwardGetVerify - verifies Get still works after refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)